### PR TITLE
Allow contextPath to be blank

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       args:
         - appAddress=${appAddress:-localhost}
         - appPort=${appPort:-8080}
-        - contextPath=${contextPath:-/labkey}
+        - contextPath=${contextPath:-}
     depends_on: 
      - ldap
     environment:


### PR DESCRIPTION
In order to test SAML against embedded Tomcat, we need to be able to have a blank contextPath. The current parameter substitution doesn't allow us to override the default contextPath with a blank value.