### PR TITLE
Add workaround for CentOS EOL

### DIFF
--- a/httpd-proxy/Dockerfile
+++ b/httpd-proxy/Dockerfile
@@ -1,5 +1,10 @@
 FROM centos:centos7
 
+# Workaround for CentOS EOL: https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
 RUN yum -y update \
     && yum -y install httpd mod_ssl mod_ldap \
     && yum -y clean all

--- a/ldap/Dockerfile
+++ b/ldap/Dockerfile
@@ -2,6 +2,11 @@ FROM centos:centos7
 
 MAINTAINER John Gasper <jgasper@unicon.net>
 
+# Workaround for CentOS EOL: https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
 RUN yum install -y epel-release \
     && yum update -y \
     && yum install -y 389-ds-base 389-adminutil \


### PR DESCRIPTION
Our SAML tests are failing because they can't build the required docker containers.

The `centos7` docker container can't install packages without some hacking: https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve

We might need a more permanent solution at some point but that will require migrating these `Dockerfile`s to be based on a different OS (My attempts to switch to `redhat` or `fedora` were unsuccessful).